### PR TITLE
修复字典库本地文件选择维度后读取失败问题

### DIFF
--- a/src/renderer/store/modules/Library.js
+++ b/src/renderer/store/modules/Library.js
@@ -142,6 +142,7 @@ const mutations = {
       }
       state.localTables[i] = f
     }
+    state.tablePage = 1
     state.localTable = state.localTables[state.tablePage]
   },
   LIBRARY_GET_FIELD(state, field) {

--- a/src/renderer/store/modules/System.js
+++ b/src/renderer/store/modules/System.js
@@ -161,7 +161,10 @@ const mutations = {
   },
   // 读取本地wt4文件目录
   SYSTEM_LOAD_WT4_FILES() {
-    const files = fs.readdirSync(global.hitbdata.path.stat).filter(x => x.endsWith('.csv'))
+    const files = fs.readdirSync(global.hitbdata.path.stat).filter(x => x.endsWith('.csv') && (x.startsWith('test_wt4_') || x.startsWith('wt4_')))
+    console.log(files);
+    // const reg = /^$/
+    // fs.filter(x => )
     state.wt4Files = files;
   },
   // 读取本地wt4文件


### PR DESCRIPTION
修复drg分组是读取表的筛选